### PR TITLE
Removed es5 option. When it was set, JSHint aborted with error.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -13,7 +13,6 @@
     "predef": [],
     "debug": false,
     "devel": false,
-    "es5": true,
     "strict": true,
     "globalstrict": true,
     "asi": false,


### PR DESCRIPTION
JSHint error:
index.js: line 0, col 0, ES5 option is now set per default (I003)
