### PR TITLE
Initial commit for browserify support

### DIFF
--- a/plugins/browserify.js
+++ b/plugins/browserify.js
@@ -1,0 +1,34 @@
+/*───────────────────────────────────────────────────────────────────────────*\
+ │  Copyright (C) 2014 eBay Software Foundation                                │
+ │                                                                             │
+ │hh ,'""`.                                                                    │
+ │  / _  _ \  Licensed under the Apache License, Version 2.0 (the "License");  │
+ │  |(@)(@)|  you may not use this file except in compliance with the License. │
+ │  )  __  (  You may obtain a copy of the License at                          │
+ │ /,'))((`.\                                                                  │
+ │(( ((  )) ))    http://www.apache.org/licenses/LICENSE-2.0                   │
+ │ `\ `)(' /'                                                                  │
+ │                                                                             │
+ │   Unless required by applicable law or agreed to in writing, software       │
+ │   distributed under the License is distributed on an "AS IS" BASIS,         │
+ │   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  │
+ │   See the License for the specific language governing permissions and       │
+ │   limitations under the License.                                            │
+ \*───────────────────────────────────────────────────────────────────────────*/
+'use strict';
+
+
+var lib = require('browserify');
+
+module.exports = function (options) {
+
+    return function (data, args, callback) {
+        var b = lib();
+        // TODO: this probably needs some finesse, but works for now.
+        b.add(process.cwd() + '/public' + args.context.filePath);
+        b.bundle({}, function(err, src) {
+            callback(null, src);
+        });
+    };
+
+};


### PR DESCRIPTION
Adding preliminary support for browserify.  Without this, trying to use browserify in kraken in development mode is useless as the copier plugin copies /public/js/\* to /.build and breaks the non-browserified JavaScript.
