### PR TITLE
Update middleware.js

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -43,7 +43,7 @@ module.exports = function middleware(srcRoot, destRoot, options, compiler) {
             // Match the base name of the file to pass to compilers
             dir = options.base || '';
             ext = path.extname(req.path).replace('.', '\\.');
-            regex = new RegExp(dir + '/(.*)' + ext +'$', 'i');
+            regex = new RegExp(dir + '/(.*)' + ext + '\/?$', 'i');
 
             // The compile context is passed through all compile steps
             context = {


### PR DESCRIPTION
Fix the "Cannot read property '1' of null" exception when the extension is followed by a slash.
