### PR TITLE
Fix trailing slash after extension bug

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -44,7 +44,7 @@ module.exports = function middleware(srcRoot, destRoot, options, compiler) {
             // Match the base name of the file to pass to compilers
             dir = options.base || '';
             ext = path.extname(req.path).replace('.', '\\.');
-            regex = new RegExp(dir + '/(.*)' + ext +'$', 'i');
+            regex = new RegExp(dir + '/(.*)' + ext + '/*$', 'i');
 
             // The compile context is passed through all compile steps
             context = {

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -43,7 +43,7 @@ module.exports = function middleware(srcRoot, destRoot, options, compiler) {
 
             // Match the base name of the file to pass to compilers
             dir = options.base || '';
-            ext = path.extname(req.path).replace('.', '\\.');
+            ext = path.extname(req.path).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
             regex = new RegExp(dir + '/(.*)' + ext + '/*$', 'i');
 
             // The compile context is passed through all compile steps

--- a/test/plugins/copier.js
+++ b/test/plugins/copier.js
@@ -92,4 +92,19 @@ describe('plugins:copier', function () {
     });
 
 
+    it('should not crash', function (done) {
+        var app = testutil.createApp({
+            copier: {
+                module: './plugins/copier',
+                files: '**/*'
+            }
+        });
+
+        request(app)
+            .get('/crash.me/')
+            .expect(404)
+            .end(done);
+    });
+
+
 });

--- a/test/plugins/copier.js
+++ b/test/plugins/copier.js
@@ -101,7 +101,7 @@ describe('plugins:copier', function () {
         });
 
         request(app)
-            .get('/crash.me/')
+            .get('/crash.me+again/')
             .expect(404)
             .end(done);
     });


### PR DESCRIPTION
Fix the "Cannot read property '1' of null" exception when a trailing slash is used after an extension.
Follow up of https://github.com/krakenjs/kraken-devtools/issues/24 and https://github.com/krakenjs/kraken-devtools/pull/27

Steps to reproduce:
* Go to http://localhost:8000/crash.me/ on any kraken app in development mode

In lib/middleware.js:
*  `ext = path.extname(req.path).replace('.', '\\.');` (45)
* `regex = new RegExp(dir + '/(.*)' + ext +'$', 'i');` (46)
* `[...] name: regex.exec(req.path)[1], [...]` (53)

The issue comes from **ext** which discards any number of trailing **/** after a detected extension (`.jpg` and `.jpg/` are both extensions in its view). These discarded **/** should be reintegrated in **regex** to allow proper matching. The fix shouldn't have any side effect on the extracted string, even when **ext** is empty.

This behavior comes from the implementation of `path.extname` in Node which can be tracked down to this regular expression `splitPathRe = /^(\/?|)([\s\S]*?)((?:\.{1,2}|[^\/]+?|)(\.[^.\/]*|))(?:[\/]*)$/;` (https://github.com/joyent/node/blob/master/lib/path.js)

Update: escape **ext** properly too (used Mozilla's escapeRegExp expression)