### PR TITLE
Upgrade less plugin to conform to less@^2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kraken-devtools",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "A development mode toolkit for kraken",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "grunt-cli": "^0.1.13",
     "grunt-contrib-jshint": "^0.7.0",
     "grunt-mocha-test": "^0.7.0",
-    "less": "^1.7.0",
+    "less": "^2.5.1",
     "localizr": "^0.1.0",
     "mocha": "^1.9.0",
     "node-sass": "^2.1.1",

--- a/plugins/less.js
+++ b/plugins/less.js
@@ -18,33 +18,34 @@
 'use strict';
 
 
-var lib = require('less');
+var less = require('less');
 
 
 module.exports = function (options) {
 
     options.ext = options.ext || 'less';
+    options.dumpLineNumbers = 'comments';
 
     return function (data, args, callback) {
-        var parser = new(lib.Parser)({
-            paths: args.paths,
-            filename: args.context.name,
-            dumpLineNumbers: 'comments'
-        });
+
+        var css = data.toString('utf8');
+
+        options.paths = args.paths;
+        options.filename = args.context.name;
 
         try {
             // Really? REALLY?! It takes an error-handling callback but still can throw errors?
-            parser.parse(data.toString('utf8'), function (err, tree) {
+            less.render(css, options, function (err, output) {
                 if (err) {
                     callback(err);
                     return;
                 }
-                callback(null, tree.toCSS());
+                callback(null, output.css);
             });
-
         } catch (err) {
             callback(err);
         }
+
     };
 
 };


### PR DESCRIPTION
`less@2.x` has been out since last October.  Let's upgrade the less plugin to conform to the `less@2.x` API.

Major bumped to 2.0.0, since this is a non-backwards compatible change.