### PR TITLE
Simplify

### DIFF
--- a/lib/noop.js
+++ b/lib/noop.js
@@ -22,8 +22,7 @@ module.exports = function noop() {
     var args = Array.prototype.slice.call(arguments);
     var callback;
 
-    if (typeof args[args.length - 1] === 'function') {
-        callback = args.pop();
+    if (typeof(callback = args.pop()) === 'function') {
         args.unshift(null);
         callback.apply(undefined, args);
     }


### PR DESCRIPTION
If you like it short, else you could declare variables only if typeof arguments[arguments.length - 1] === 'function' and so use less memory in the else case and get a fester function