### PR TITLE
Update sass plugin to support the changed callback methods for node-sass

### DIFF
--- a/plugins/sass.js
+++ b/plugins/sass.js
@@ -36,6 +36,13 @@ module.exports = function (options) {
                 callback(err);
             },
             includePaths: args.paths
+        }, function(err, result) {
+            if(err) {
+                err.status = 500;
+                callback(err)
+            } else {
+                callback(null, result.css || result);
+            }
         });
     };
 


### PR DESCRIPTION
It seems that somewhere down the line node-sass removed their success and error callback methods. This PR should fix the plugin and still be backwards compatible.

Please let me know if any changes are required.